### PR TITLE
Add ends_at on Event

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -31,7 +31,8 @@ class EventController extends Controller
 
         Event::create([
             ...$data,
-            'starts_at' => Carbon::createFromFormat('Y-m-d H:i', $data['starts_at'])
+            'starts_at' => Carbon::createFromFormat('Y-m-d H:i', $data['starts_at']),
+            'ends_at'   => Carbon::createFromFormat('Y-m-d H:i', $data['ends_at']),
         ]);
 
         return Redirect::back();
@@ -43,7 +44,8 @@ class EventController extends Controller
 
         $event->update([
             ...$data,
-            'starts_at' => Carbon::createFromFormat('Y-m-d H:i', $data['starts_at'])
+            'starts_at' => Carbon::createFromFormat('Y-m-d H:i', $data['starts_at']),
+            'ends_at'   => Carbon::createFromFormat('Y-m-d H:i', $data['ends_at']),
         ]);
 
         return Redirect::back();

--- a/app/Http/Requests/EventRequest.php
+++ b/app/Http/Requests/EventRequest.php
@@ -25,7 +25,8 @@ class EventRequest extends FormRequest
     {
         return [
             'title' => ['required', 'max:255'],
-            'starts_at' => ['required', 'date:Y-m-d H:i']
+            'starts_at' => ['required', 'date:Y-m-d H:i'],
+            'ends_at' => ['required', 'date:Y-m-d H:i']
         ];
     }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -11,7 +11,7 @@ class Event extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['title', 'starts_at'];
+    protected $fillable = ['title', 'starts_at', 'ends_at'];
 
     /**
      * Scope a query to only include events that occure between two dates.

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -3,9 +3,9 @@
 namespace App\Models;
 
 use DateTime;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Event extends Model
 {
@@ -16,29 +16,29 @@ class Event extends Model
     /**
      * Scope a query to only include events that occure between two dates.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  Builder  $query
      * @param  DateTime  $startsAt
      * @param  DateTime  $endsAt
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     public function scopeIsBetween($query, $startsAt, $endsAt)
     {
-        if ($startsAt && !$endsAt) {
-            $query->whereDate('events.starts_at', '=', $startsAt);
-        } elseif ($startsAt && $endsAt) {
-            $query->whereDate('events.starts_at', '>', $startsAt)
-                  ->whereDate('events.starts_at', '<', $endsAt);
-        }
+        $query->when($startsAt && !$endsAt, function (Builder $query) use ($startsAt) {
+            $query->whereDate('events.starts_at', '<=', $startsAt)->whereDate('events.ends_at', '>=', $startsAt);
+        })->when($startsAt && $endsAt, function (Builder $query) use ($startsAt, $endsAt) {
+            $query->where(function (Builder $query) use ($startsAt, $endsAt) {
+                $query->where('events.starts_at', '<=', $endsAt)
+                    ->where('events.ends_at', '>=', $startsAt);
+            });
+        });
         return $query;
     }
 
     /**
-     * Scope a query to only include events that occure between two dates.
+     * Scope a query to order events by their start date.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  DateTime  $startsAt
-     * @param  DateTime  $endsAt
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @param  Builder  $query
+     * @return Builder
      */
     public function scopeOrderByDate($query)
     {

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -21,9 +21,11 @@ class EventFactory extends Factory
      */
     public function definition()
     {
+        $date = $this->faker->dateTimeThisYear();
         return [
             'title' => $this->faker->jobTitle(),
-            'starts_at' => $this->faker->dateTimeThisYear()
+            'starts_at' => $date,
+            'ends_at' => (clone $date)->modify('+'.rand(1, 720).' hours')
         ];
     }
 }

--- a/database/migrations/2025_08_29_032355_add_ends_at_in_events_table.php
+++ b/database/migrations/2025_08_29_032355_add_ends_at_in_events_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateEventsTable extends Migration
+class AddEndsAtInEventsTable extends Migration
 {
     /**
      * Run the migrations.
@@ -13,11 +13,8 @@ class CreateEventsTable extends Migration
      */
     public function up()
     {
-        Schema::create('events', function (Blueprint $table) {
-            $table->id();
-            $table->string('title');
-            $table->timestamp('starts_at');
-            $table->timestamps();
+        Schema::table('events', function (Blueprint $table) {
+            $table->timestamp('ends_at');
         });
     }
 
@@ -28,6 +25,8 @@ class CreateEventsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('events');
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('ends_at');
+        });
     }
 }

--- a/database/seeders/EventSeeder.php
+++ b/database/seeders/EventSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\Event;
+use DateTime;
 use Illuminate\Database\Seeder;
 
 class EventSeeder extends Seeder
@@ -16,6 +17,13 @@ class EventSeeder extends Seeder
     {
         if (!Event::exists()) {
             Event::factory()->count(100)->create();
+        } else {
+
+            foreach (Event::all() as $event) {
+                $event->update([
+                    'ends_at' => (new DateTime($event->starts_at))->modify('+'.rand(1, 720).' hours'),
+                ]);
+            }
         }
     }
 }

--- a/resources/js/Pages/Events/Index.vue
+++ b/resources/js/Pages/Events/Index.vue
@@ -137,16 +137,16 @@ const onDelete = () => {
             <div class="card-body">
                 <Table
                     :data="events.data"
-                    :headings="['Title', 'Date', 'Actions']"
+                    :headings="['Title', 'Start', 'End', 'Actions']"
                 >
                     <template #row="{ item }">
                         <td>{{ item.title }}</td>
                         <td>
                             {{ moment(item.starts_at).format("HH:mm DD/MM/YYYY") }}
                         </td>
-                        <!--<td>
+                        <td>
                             {{ moment(item.ends_at).format("HH:mm DD/MM/YYYY") }}
-                        </td>-->
+                        </td>
                         <td>
                             <span
                                 class="px-2 text-gray-700 hover:text-blue-500 cursor-pointer transition"

--- a/resources/js/Pages/Events/Partials/AddEditDialog.vue
+++ b/resources/js/Pages/Events/Partials/AddEditDialog.vue
@@ -23,7 +23,7 @@ const editing = ref(false);
 const form = useForm({
     title: "",
     starts_at: null,
-    //ends_at: null,
+    ends_at: null,
 });
 
 watch (() => props.itemToEdit, (itemSelected) => {
@@ -31,6 +31,7 @@ watch (() => props.itemToEdit, (itemSelected) => {
         form.reset();
         form.title = itemSelected.title;
         form.starts_at = moment(itemSelected.starts_at);
+        form.ends_at = moment(itemSelected.ends_at);
         show.value = true;
         editing.value = true;
     }
@@ -48,6 +49,7 @@ const onSubmit = () => {
     const transform = (data) => ({
         ...data,
         starts_at: data.starts_at.format("YYYY-MM-DD HH:mm"),
+        ends_at: data.ends_at.format("YY-MM-DD HH:mm"),
     });
 
     const requestParams = {
@@ -91,23 +93,30 @@ const onClose = () => {
             <template #header>{{
                 editing ? "Edit event" : "Add new event"
             }}</template>
-
+            <div class="grid grid-cols-2 gap-2">
             <Input
                 name="title"
                 label="Title"
                 v-model="form.title"
-                class="mb-6"
+                class="mb-6 col-span-2"
                 :error="form.errors.title"
             />
+                <DateTimePicker
+                    name="starts_at"
+                    label="Starts at"
+                    v-model="form.starts_at"
+                    class="mb-6"
+                    :error="form.errors.starts_at"
+                />
 
-            <DateTimePicker
-                name="starts_at"
-                label="Starts at"
-                v-model="form.starts_at"
-                class="mb-6"
-                :error="form.errors.starts_at"
-            />
-
+                <DateTimePicker
+                    name="ends_at"
+                    label="Ends at"
+                    v-model="form.ends_at"
+                    class="mb-6"
+                    :error="form.errors.ends_at"
+                />
+            </div>
             <template #footer>
                 <Button
                     variant="secondary"


### PR DESCRIPTION
# Add Ends_at datetime on Event

- implements ends_at on migrations, event, seeder and factories
- add ends_at on form and date treatment
- add ends_at on table and is_between filters.

## NEW ScopeIsBetween
### Before
- ScopeIsBetween check starts_at on all Event between range indicated.
- If you only fill "start date" for filter, all Event "start" on this date will be displayed
### After
- ScopeIsBetween check all event started before "end date" and event end before "start date" will be displayed.
- If you only fill "start date" for filter, all event started before "start date" AND ended after "start date" will be displayed